### PR TITLE
Callback for basic TLS cert check

### DIFF
--- a/aqbanking/aqbanking.cpp
+++ b/aqbanking/aqbanking.cpp
@@ -599,6 +599,26 @@ static PyObject *aqbanking_Account_set_callbackPassword(aqbanking_Account* self,
 	return result;
 }
 
+static PyObject *aqbanking_Account_set_callbackCheckCert(aqbanking_Account* self, PyObject *args)
+{
+	PyObject *result = NULL;
+	PyObject *temp;
+
+	if (PyArg_ParseTuple(args, "O:set_callbackCheckCert", &temp)) {
+		if (!PyCallable_Check(temp)) {
+			PyErr_SetString(PyExc_TypeError, "parameter must be callable");
+			return NULL;
+		}
+		Py_XINCREF(temp);         /* Add a reference to new callback */
+		Py_XDECREF(self->aqh->callbackCheckCert);  /* Dispose of previous callback */
+		self->aqh->callbackCheckCert = temp;       /* Remember new callback */
+		/* Boilerplate to return "None" */
+		Py_INCREF(Py_None);
+		result = Py_None;
+	}
+	return result;
+}
+
 static PyObject *aqbanking_Account_balance(aqbanking_Account* self, PyObject *args, PyObject *keywds)
 {
 	const AB_ACCOUNT_STATUS * status;
@@ -1116,6 +1136,7 @@ static PyMethodDef aqbanking_Account_methods[] = {
 	{"availableJobs", (PyCFunction)aqbanking_Account_available_jobs, METH_VARARGS | METH_KEYWORDS, "Get a list of available jobs."},
 	{"set_callbackLog", (PyCFunction)aqbanking_Account_set_callbackLog, METH_VARARGS, "Adds a callback for the log output."},
 	{"set_callbackPassword", (PyCFunction)aqbanking_Account_set_callbackPassword, METH_VARARGS, "Adds a callback to retrieve the password (pin)."},
+	{"set_callbackCheckCert", (PyCFunction)aqbanking_Account_set_callbackCheckCert, METH_VARARGS, "Adds a callback to check the certificate."},
 	{NULL}  /* Sentinel */
 };
 

--- a/aqbanking/pyaqhandler.hpp
+++ b/aqbanking/pyaqhandler.hpp
@@ -22,6 +22,7 @@ public:
 	 */
 	PyObject *callbackLog;
 	PyObject *callbackPassword;
+	PyObject *callbackCheckCert;
 
 protected:
 	virtual int logHook(const char* logDomain, GWEN_LOGGER_LEVEL level, const char *s);


### PR DESCRIPTION
This callback at the moment only allows to check the sha512 hash. The comparison of the common name is not meaningful.
If the callback is not set there are still no checks! This should be changed in future.

I have to admit that the documentation is missing. Usage:

```
def print_cert(args):
    if args["sha512"] == "DF:A2:CE:07:EB:FA:F7:47:EA:56:7A:22:AD:6D:53:75:B7:BD:E3:…":
        return True
    else:
        print("Zert abgelehnt")
        return False

account.set_callbackCheckCert(print_cert)
```